### PR TITLE
Next keyboard button finally looks like the other buttons

### DIFF
--- a/CustomKeyboards.xcodeproj/project.pbxproj
+++ b/CustomKeyboards.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		874A73D21FDCB1300074219C /* DoubledKeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A73D11FDCB1300074219C /* DoubledKeyboardViewController.swift */; };
 		874A73D61FDCB1300074219C /* DoubledLetters.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 874A73CF1FDCB1300074219C /* DoubledLetters.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		874A73DA1FDCB16C0074219C /* KeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A73C71FDC78680074219C /* KeyboardViewController.swift */; };
-		874A73DB1FDCB5D60074219C /* DocumentProxyDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C248341FD63CFD00C87862 /* DocumentProxyDelegate.swift */; };
+		874A73DB1FDCB5D60074219C /* KeyboardViewControllerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C248341FD63CFD00C87862 /* KeyboardViewControllerProxy.swift */; };
 		8750E48E1FDCB68E00241610 /* Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FAAE4B1FD0F1850051F6BA /* Keyboard.swift */; };
 		8750E48F1FDCB69C00241610 /* KeyboardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8748F7EC1FCD066700CBF5C5 /* KeyboardButton.swift */; };
 		8750E4961FE0C00000241610 /* LetterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8750E4951FE0C00000241610 /* LetterButton.swift */; };
@@ -32,6 +32,10 @@
 		8750E4A61FE4A5E600241610 /* SpaceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8750E4A41FE4A59F00241610 /* SpaceButton.swift */; };
 		8750E4A71FE4A5E600241610 /* SpaceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8750E4A41FE4A59F00241610 /* SpaceButton.swift */; };
 		8750E4A81FE4A5E700241610 /* SpaceButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8750E4A41FE4A59F00241610 /* SpaceButton.swift */; };
+		8750E4AC1FE5BDB100241610 /* NextKeyboardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8750E4AB1FE5BDB100241610 /* NextKeyboardButton.swift */; };
+		8750E4AD1FE5C0A500241610 /* NextKeyboardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8750E4AB1FE5BDB100241610 /* NextKeyboardButton.swift */; };
+		8750E4AE1FE5C0A600241610 /* NextKeyboardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8750E4AB1FE5BDB100241610 /* NextKeyboardButton.swift */; };
+		8750E4AF1FE5C0A600241610 /* NextKeyboardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8750E4AB1FE5BDB100241610 /* NextKeyboardButton.swift */; };
 		87BA96971FCCFA2400FD7E7A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BA96961FCCFA2400FD7E7A /* AppDelegate.swift */; };
 		87BA96991FCCFA2400FD7E7A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87BA96981FCCFA2400FD7E7A /* ViewController.swift */; };
 		87BA969C1FCCFA2400FD7E7A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 87BA969A1FCCFA2400FD7E7A /* Main.storyboard */; };
@@ -43,9 +47,9 @@
 		87BA96CF1FCCFA3B00FD7E7A /* EmojiLetters.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 87BA96C81FCCFA3A00FD7E7A /* EmojiLetters.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		87C248321FD1070700C87862 /* Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FAAE4B1FD0F1850051F6BA /* Keyboard.swift */; };
 		87C248331FD1070800C87862 /* Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FAAE4B1FD0F1850051F6BA /* Keyboard.swift */; };
-		87C248361FD6400F00C87862 /* DocumentProxyDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C248341FD63CFD00C87862 /* DocumentProxyDelegate.swift */; };
-		87F8412F1FD9106D00F35AF8 /* DocumentProxyDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C248341FD63CFD00C87862 /* DocumentProxyDelegate.swift */; };
-		87F841311FD910BC00F35AF8 /* DocumentProxyDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C248341FD63CFD00C87862 /* DocumentProxyDelegate.swift */; };
+		87C248361FD6400F00C87862 /* KeyboardViewControllerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C248341FD63CFD00C87862 /* KeyboardViewControllerProxy.swift */; };
+		87F8412F1FD9106D00F35AF8 /* KeyboardViewControllerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C248341FD63CFD00C87862 /* KeyboardViewControllerProxy.swift */; };
+		87F841311FD910BC00F35AF8 /* KeyboardViewControllerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C248341FD63CFD00C87862 /* KeyboardViewControllerProxy.swift */; };
 		87FAAE381FCFD49E0051F6BA /* KeyboardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8748F7EC1FCD066700CBF5C5 /* KeyboardButton.swift */; };
 		87FAAE3A1FCFD4ED0051F6BA /* KeyboardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8748F7EC1FCD066700CBF5C5 /* KeyboardButton.swift */; };
 		87FAAE421FCFD53C0051F6BA /* DotMatrixKeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FAAE411FCFD53C0051F6BA /* DotMatrixKeyboardViewController.swift */; };
@@ -118,6 +122,7 @@
 		8750E4971FE0CE1A00241610 /* Tappable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tappable.swift; sourceTree = "<group>"; };
 		8750E49F1FE215B200241610 /* BackspaceButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackspaceButton.swift; sourceTree = "<group>"; };
 		8750E4A41FE4A59F00241610 /* SpaceButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceButton.swift; sourceTree = "<group>"; };
+		8750E4AB1FE5BDB100241610 /* NextKeyboardButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextKeyboardButton.swift; sourceTree = "<group>"; };
 		87BA96931FCCFA2400FD7E7A /* CustomKeyboards.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CustomKeyboards.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		87BA96961FCCFA2400FD7E7A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		87BA96981FCCFA2400FD7E7A /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -134,7 +139,7 @@
 		87BA96C81FCCFA3A00FD7E7A /* EmojiLetters.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = EmojiLetters.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		87BA96CA1FCCFA3B00FD7E7A /* EmojiKeyboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiKeyboardViewController.swift; sourceTree = "<group>"; };
 		87BA96CC1FCCFA3B00FD7E7A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		87C248341FD63CFD00C87862 /* DocumentProxyDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentProxyDelegate.swift; sourceTree = "<group>"; };
+		87C248341FD63CFD00C87862 /* KeyboardViewControllerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardViewControllerProxy.swift; sourceTree = "<group>"; };
 		87FAAE3F1FCFD53C0051F6BA /* DotMatrixLetters.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = DotMatrixLetters.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		87FAAE411FCFD53C0051F6BA /* DotMatrixKeyboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotMatrixKeyboardViewController.swift; sourceTree = "<group>"; };
 		87FAAE431FCFD53C0051F6BA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -230,12 +235,13 @@
 				87BA96981FCCFA2400FD7E7A /* ViewController.swift */,
 				87FAAE4B1FD0F1850051F6BA /* Keyboard.swift */,
 				874A73C71FDC78680074219C /* KeyboardViewController.swift */,
-				87C248341FD63CFD00C87862 /* DocumentProxyDelegate.swift */,
+				87C248341FD63CFD00C87862 /* KeyboardViewControllerProxy.swift */,
 				8748F7EC1FCD066700CBF5C5 /* KeyboardButton.swift */,
 				8750E4971FE0CE1A00241610 /* Tappable.swift */,
 				8750E49F1FE215B200241610 /* BackspaceButton.swift */,
 				8750E4951FE0C00000241610 /* LetterButton.swift */,
 				8750E4A41FE4A59F00241610 /* SpaceButton.swift */,
+				8750E4AB1FE5BDB100241610 /* NextKeyboardButton.swift */,
 				87BA969F1FCCFA2400FD7E7A /* LaunchScreen.storyboard */,
 				87BA969A1FCCFA2400FD7E7A /* Main.storyboard */,
 				87BA969D1FCCFA2400FD7E7A /* Assets.xcassets */,
@@ -506,7 +512,8 @@
 			files = (
 				8750E48F1FDCB69C00241610 /* KeyboardButton.swift in Sources */,
 				8750E49E1FE214B300241610 /* LetterButton.swift in Sources */,
-				874A73DB1FDCB5D60074219C /* DocumentProxyDelegate.swift in Sources */,
+				874A73DB1FDCB5D60074219C /* KeyboardViewControllerProxy.swift in Sources */,
+				8750E4AF1FE5C0A600241610 /* NextKeyboardButton.swift in Sources */,
 				874A73D21FDCB1300074219C /* DoubledKeyboardViewController.swift in Sources */,
 				8750E49B1FE214AF00241610 /* Tappable.swift in Sources */,
 				8750E4A31FE215C100241610 /* BackspaceButton.swift in Sources */,
@@ -525,7 +532,8 @@
 				874A73C81FDC78680074219C /* KeyboardViewController.swift in Sources */,
 				8750E4981FE0CE1A00241610 /* Tappable.swift in Sources */,
 				87BA96991FCCFA2400FD7E7A /* ViewController.swift in Sources */,
-				87F8412F1FD9106D00F35AF8 /* DocumentProxyDelegate.swift in Sources */,
+				8750E4AC1FE5BDB100241610 /* NextKeyboardButton.swift in Sources */,
+				87F8412F1FD9106D00F35AF8 /* KeyboardViewControllerProxy.swift in Sources */,
 				87FAAE4C1FD0F1850051F6BA /* Keyboard.swift in Sources */,
 				87BA96971FCCFA2400FD7E7A /* AppDelegate.swift in Sources */,
 				8750E4A51FE4A59F00241610 /* SpaceButton.swift in Sources */,
@@ -556,10 +564,11 @@
 				87FAAE3A1FCFD4ED0051F6BA /* KeyboardButton.swift in Sources */,
 				8750E49C1FE214B200241610 /* LetterButton.swift in Sources */,
 				874A73C91FDC78FE0074219C /* KeyboardViewController.swift in Sources */,
+				8750E4AD1FE5C0A500241610 /* NextKeyboardButton.swift in Sources */,
 				87C248321FD1070700C87862 /* Keyboard.swift in Sources */,
 				8750E4991FE214AD00241610 /* Tappable.swift in Sources */,
 				8750E4A11FE215C000241610 /* BackspaceButton.swift in Sources */,
-				87C248361FD6400F00C87862 /* DocumentProxyDelegate.swift in Sources */,
+				87C248361FD6400F00C87862 /* KeyboardViewControllerProxy.swift in Sources */,
 				87BA96CB1FCCFA3B00FD7E7A /* EmojiKeyboardViewController.swift in Sources */,
 				8750E4A61FE4A5E600241610 /* SpaceButton.swift in Sources */,
 			);
@@ -572,10 +581,11 @@
 				87FAAE4A1FCFD5430051F6BA /* KeyboardButton.swift in Sources */,
 				8750E49D1FE214B300241610 /* LetterButton.swift in Sources */,
 				874A73CA1FDC7FFB0074219C /* KeyboardViewController.swift in Sources */,
+				8750E4AE1FE5C0A600241610 /* NextKeyboardButton.swift in Sources */,
 				87C248331FD1070800C87862 /* Keyboard.swift in Sources */,
 				8750E49A1FE214AE00241610 /* Tappable.swift in Sources */,
 				8750E4A21FE215C000241610 /* BackspaceButton.swift in Sources */,
-				87F841311FD910BC00F35AF8 /* DocumentProxyDelegate.swift in Sources */,
+				87F841311FD910BC00F35AF8 /* KeyboardViewControllerProxy.swift in Sources */,
 				87FAAE421FCFD53C0051F6BA /* DotMatrixKeyboardViewController.swift in Sources */,
 				8750E4A71FE4A5E600241610 /* SpaceButton.swift in Sources */,
 			);

--- a/CustomKeyboards/BackspaceButton.swift
+++ b/CustomKeyboards/BackspaceButton.swift
@@ -14,6 +14,6 @@ class BackspaceButton : KeyboardButton {
         // TODO: Figure out how to set pressed and unpressed colors
         // self.backgroundColor = UIColor.init(white: 0.5, alpha: 1)
         self.playInputClick(soundId: self.deleteSoundId)
-        self.documentProxyDelegate.deleteText()
+        self.proxyDelegate.deleteText()
     }
 }

--- a/CustomKeyboards/Keyboard.swift
+++ b/CustomKeyboards/Keyboard.swift
@@ -19,24 +19,20 @@ class Keyboard {
     let horizontalSpaceBetweenButtons = CGFloat(7.0)
     let verticalSpaceBetweenButtons = CGFloat(10.0)
 
-    var keyboardWidth : CGFloat
-    var keyboardHeight : CGFloat
+    var keyboardWidth : CGFloat!
+    var keyboardHeight : CGFloat!
 
-    var buttonWidth : CGFloat
-    var buttonHeight : CGFloat
+    var buttonWidth : CGFloat!
+    var buttonHeight : CGFloat!
 
-    var letterRows : [[String]]
-
-    init(_ letterRows : [[String]]) {
-        self.letterRows = letterRows
-        
-        self.keyboardWidth = CGFloat(320.0)
+    init(_ width: CGFloat) {
+        self.keyboardWidth = width
         self.keyboardHeight = CGFloat(226.0)
 
-        self.buttonWidth = self.keyboardWidth
-            - CGFloat(self.letterRows[0].count-1)*horizontalSpaceBetweenButtons
+        self.buttonWidth = (self.keyboardWidth
+            - 9*self.horizontalSpaceBetweenButtons
             - self.leftMargin
-            - self.rightMargin
+            - self.rightMargin)/10.0
         self.buttonHeight = (self.keyboardHeight - topMargin - bottomMargin - 3*self.verticalSpaceBetweenButtons)/4.0
     }
 }

--- a/CustomKeyboards/KeyboardButton.swift
+++ b/CustomKeyboards/KeyboardButton.swift
@@ -18,16 +18,16 @@ class KeyboardButton : UIView {
 
     var labelText : String
     var delegate: Tappable!
-    var documentProxyDelegate : DocumentProxyDelegate
+    var proxyDelegate : KeyboardViewControllerProxy
 
     // Needed to keep XCode happy
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    init(_ labelText: String, height: CGFloat, documentProxyDelegate: DocumentProxyDelegate) {
+    init(_ labelText: String, proxyDelegate: KeyboardViewControllerProxy) {
         self.labelText = labelText
-        self.documentProxyDelegate = documentProxyDelegate
+        self.proxyDelegate = proxyDelegate
         super.init(frame: CGRect.zero)
 
         let newButtonLabel = UILabel()
@@ -37,7 +37,6 @@ class KeyboardButton : UIView {
         newButtonLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
         newButtonLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
         
-        self.heightAnchor.constraint(equalToConstant: height).isActive = true
         self.backgroundColor = UIColor.init(white: 1, alpha: 1)
         self.translatesAutoresizingMaskIntoConstraints = false
         self.layer.cornerRadius = 4.0

--- a/CustomKeyboards/KeyboardViewControllerProxy.swift
+++ b/CustomKeyboards/KeyboardViewControllerProxy.swift
@@ -1,5 +1,5 @@
 //
-//  DocumentProxyDelegate.swift
+//  KeyboardViewControllerProxy.swift
 //  CustomKeyboards
 //
 //  Created by danielle kefford on 12/4/17.
@@ -8,8 +8,10 @@
 
 /// This protocol declares the set of operations that need to be implemented
 /// for modifying the underlying document for a specific UIViewController instance.
-protocol DocumentProxyDelegate {
+protocol KeyboardViewControllerProxy {
     mutating func insertText(buttonText: String)
 
     mutating func deleteText()
+
+    mutating func advanceToNextKeyboard()
 }

--- a/CustomKeyboards/LetterButton.swift
+++ b/CustomKeyboards/LetterButton.swift
@@ -12,6 +12,6 @@ import UIKit
 class LetterButton : KeyboardButton {
     override func handleTap(_ recognizer: UITapGestureRecognizer) {
         self.playInputClick(soundId: self.clickSoundId)
-        self.documentProxyDelegate.insertText(buttonText: labelText)
+        self.proxyDelegate.insertText(buttonText: labelText)
     }
 }

--- a/CustomKeyboards/NextKeyboardButton.swift
+++ b/CustomKeyboards/NextKeyboardButton.swift
@@ -1,18 +1,17 @@
 //
-//  SpaceButton.swift
+//  NextKeyboardButton.swift
 //  CustomKeyboards
 //
-//  Created by danielle kefford on 12/15/17.
+//  Created by danielle kefford on 12/16/17.
 //  Copyright © 2017 danielle kefford. All rights reserved.
 //
 
 import UIKit
 
-/// Specialized class for the spacebar
-class SpaceButton : KeyboardButton {
+/// Specialized class for the backspace button
+class NextKeyboardButton : KeyboardButton {
     override func handleTap(_ recognizer: UITapGestureRecognizer) {
         self.playInputClick(soundId: self.modifierSoundId)
-        self.proxyDelegate.insertText(buttonText: labelText)
+        self.proxyDelegate.advanceToNextKeyboard()
     }
 }
-

--- a/CustomKeyboards/ViewController.swift
+++ b/CustomKeyboards/ViewController.swift
@@ -21,7 +21,4 @@ class ViewController: UIViewController {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
-
-
 }
-


### PR DESCRIPTION
* Made new `NextKeyboardButton` class
* Renamed proxy class to capture that it has a more general purpose
* Made next keyboard and backspace buttons square as they are in the default keyboard
* Split out layout of letter buttons into separate top level method in `KeyboardViewController`
* `Keyboard` class now has number of buttons in top row hardcoded since that never changes and it has no need to access the array of button labels.